### PR TITLE
Add utility function to CompositeSensor

### DIFF
--- a/src/main/java/it/units/erallab/hmsrobots/core/sensors/CompositeSensor.java
+++ b/src/main/java/it/units/erallab/hmsrobots/core/sensors/CompositeSensor.java
@@ -72,5 +72,9 @@ public abstract class CompositeSensor extends AbstractSensor {
   public Sensor getSensor() {
     return sensor;
   }
+  
+  public Sensor getInnermostSensor() {
+    return sensor instanceof CompositeSensor ? sensor.getInnermostSensor() : sensor;
+  }
 
 }


### PR DESCRIPTION
This may be useful for type checking the innermost sensor, for example when some normalization hides the real type of a sensor.